### PR TITLE
Add mysql jdbc dependency to maven-jetty-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,11 @@
                         <artifactId>log4j</artifactId>
                         <version>${log4j.version}</version>
                     </dependency>
+                    <dependency>
+                        <groupId>mysql</groupId>
+                        <artifactId>mysql-connector-java</artifactId>
+                        <version>5.1.31</version>
+                    </dependency>
                 </dependencies>
                 <configuration>
                     <webApp>${project.build.directory}/${project.build.finalName}</webApp>


### PR DESCRIPTION
Pulls in the mysql jdbc driver as a dependency of the jetty maven plugin (and not the portal as a whole).

AC: Using this change, make sure jdbc.{user,password} are set in env.properties and the mysql jdbc jar is not on the classpath from elsewhere, and run "mvn clean jetty:run". It should start the development server without throwing the following exception:

PropertyAccessException 1: org.springframework.beans.MethodInvocationException: Property 'driverClassName' threw exception; nested exception is java.lang.IllegalStateException: Could not load JDBC driver class [com.mysql.jdbc.Driver]
