### PR TITLE
Ids for ANUGA and eScript snapshots on nectar

### DIFF
--- a/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/src/main/webapp/WEB-INF/applicationContext.xml
@@ -260,7 +260,7 @@
         <property name="availableImages">
             <list>
                 <bean class="org.auscope.portal.server.vegl.VglMachineImage">
-                    <constructor-arg name="imageId" value="Melbourne/96130956-ad24-4d77-8155-b7f1fb688fd1"/>
+                    <constructor-arg name="imageId" value="Melbourne/85728cb8-5ff3-4110-91ab-a5567f714ca0"/>
                     <property name="name" value="escript"/>
                     <property name="description"><value>A Centos 6 machine with escript already installed.</value></property>
                     <property name="keywords">
@@ -271,7 +271,7 @@
                     </property>
                 </bean>
                 <bean class="org.auscope.portal.server.vegl.VglMachineImage">
-                    <constructor-arg name="imageId" value="Melbourne/4ab32e29-14cb-4eb8-9580-93c14a80108f"/>
+                    <constructor-arg name="imageId" value="Melbourne/7fa567fb-24bb-412b-8c15-5002370ca199"/>
                     <property name="name" value="ANUGA"/>
                     <property name="description"><value>A Centos 6 machine with ANUGA already installed.</value></property>
                     <property name="keywords">


### PR DESCRIPTION
New snapshots on nectar for ANUGA and eScript images.

ANUGA tutorial appears to run OK, not sure how to run the eScript example to check it (what input(s) does it require?).
