### PR TITLE
version naming error and nexus version name issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
         <targetJdk>1.7</targetJdk>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <powermock.version>1.5.6</powermock.version>
-        <portal.core.version>1.1.0-JobBranch-Release</portal.core.version>
+        <portal.core.version>1.1.0-JobBranch</portal.core.version>
         <httpclient.version>4.3.5</httpclient.version>
     </properties>
 


### PR DESCRIPTION
Pick the portal-core release version name change from the v2 release branch
