### PR TITLE
Upload File Form: Add Metadata

### DIFF
--- a/src/main/db/mysql/vhirlportal_upgrade_pull53_file_upload_metadata_form.sql
+++ b/src/main/db/mysql/vhirlportal_upgrade_pull53_file_upload_metadata_form.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS `uploads` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+    `name` varchar(255) DEFAULT NULL,
+    `fileName` varchar(255) DEFAULT NULL,
+    `size` bigint(20) DEFAULT NULL,
+    `directoryFlag` bit(1) DEFAULT NULL,
+    `parentPath` varchar(255) DEFAULT NULL,
+    `owner` varchar(255) DEFAULT NULL,
+    `date` datetime DEFAULT NULL,
+    `description` varchar(255) DEFAULT NULL,
+    `copyright` varchar(255) DEFAULT NULL,
+    `jobId` int(11) NOT NULL,
+    PRIMARY KEY (`id`),
+  KEY `jobId` (`jobId`)
+);

--- a/src/main/db/mysql/vhirlportal_uploads.sql
+++ b/src/main/db/mysql/vhirlportal_uploads.sql
@@ -1,0 +1,62 @@
+CREATE DATABASE  IF NOT EXISTS `vhirlportal` /*!40100 DEFAULT CHARACTER SET latin1 */;
+USE `vhirlportal`;
+-- MySQL dump 10.13  Distrib 5.1.40, for Win32 (ia32)
+--
+-- Host: localhost    Database: vhirlportal
+-- ------------------------------------------------------
+-- Server version	5.1.49-3-log
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `jobs`
+--
+
+DROP TABLE IF EXISTS `uploads`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `uploads` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+    `name` varchar(255) DEFAULT NULL,
+    `fileName` varchar(255) DEFAULT NULL,
+    `size` bigint(20) DEFAULT NULL,
+    `directoryFlag` bit(1) DEFAULT NULL,
+    `parentPath` varchar(255) DEFAULT NULL,
+    `owner` varchar(255) DEFAULT NULL,
+    `date` datetime DEFAULT NULL,
+    `description` varchar(255) DEFAULT NULL,
+    `copyright` varchar(255) DEFAULT NULL,
+    `jobId` int(11) NOT NULL,
+    PRIMARY KEY (`id`),
+  KEY `jobId` (`jobId`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `jobs`
+--
+
+LOCK TABLES `uploads` WRITE;
+/*!40000 ALTER TABLE `uploads` DISABLE KEYS */;
+/*!40000 ALTER TABLE `uploads` ENABLE KEYS */;
+UNLOCK TABLES;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2011-07-07 17:06:53

--- a/src/main/java/org/auscope/portal/server/gridjob/FileInformation.java
+++ b/src/main/java/org/auscope/portal/server/gridjob/FileInformation.java
@@ -6,8 +6,16 @@
  */
 package org.auscope.portal.server.gridjob;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.auscope.portal.server.vegl.VEGLJob;
+
 import java.io.File;
 import java.io.Serializable;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 /**
  * Simple bean class that stores basic information about a file. Designed to be passed between GUI and backend
@@ -16,8 +24,15 @@ import java.io.Serializable;
  */
 public class FileInformation implements Serializable {
     private static final long serialVersionUID = -7357222903106188095L;
-    
+
+
+    protected final Log logger = LogFactory.getLog(getClass());
+
+    /** The primary key for this download*/
+    private Integer id;
     /** The filename */
+    private String fileName;
+    /** The data name */
     private String name;
     /** The file size in bytes */
     private long size;
@@ -25,6 +40,22 @@ public class FileInformation implements Serializable {
     private boolean directoryFlag = false;
     /** parent directory path */
     private String parentPath = "";
+    /** owner */
+    private String owner;
+    /** date */
+    private Date date;
+    /** data description */
+    private String description;
+    /** copyright status */
+    private String copyright;
+    /** job */
+    private VEGLJob parent;
+
+    // Creates an un-initialized instance
+    public FileInformation() {
+        super();
+    }
+
 
     public FileInformation(File file) {
     	this.name = file.getName();
@@ -33,14 +64,27 @@ public class FileInformation implements Serializable {
     	this.parentPath = file.getParent();
     }
     
-    public FileInformation(String name, long size, boolean directoryFlag,
+    public FileInformation(String fileName, long size, boolean directoryFlag,
 			String parentPath) {
 		super();
-		this.name = name;
+		this.fileName = fileName;
 		this.size = size;
 		this.directoryFlag = directoryFlag;
 		this.parentPath = parentPath;
 	}
+
+    public FileInformation(String fileName, long size, boolean directoryFlag, String parentPath, String owner, String date) {
+        this(fileName, size, directoryFlag, parentPath);
+        this.owner = owner;
+        setDate(date);
+    }
+
+    public FileInformation(String fileName, String dataName, long size, boolean directoryFlag, String parentPath, String owner, String date, String description, String copyright) {
+        this(fileName, size, directoryFlag, parentPath, owner, date);
+        this.name = dataName;
+        this.description = description;
+        this.copyright = copyright;
+    }
 
 	/**
      * Returns the filename.
@@ -96,4 +140,78 @@ public class FileInformation implements Serializable {
 	public void setParentPath(String parentPath) {
 		this.parentPath = parentPath;
 	}
+
+
+    public VEGLJob getParent() {
+        return parent;
+    }
+
+    public void setParent(VEGLJob parent) {
+        this.parent = parent;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
+    }
+
+    public void setDate(String date) {
+        DateFormat format = new SimpleDateFormat("dd/MM/yyyy");
+        try {
+            this.date = format.parse(date);
+        } catch (ParseException e) {
+            logger.error(e);
+        }
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getCopyright() {
+        return copyright;
+    }
+
+    public void setCopyright(String copyright) {
+        this.copyright = copyright;
+    }
+
+    public void setSize(long size) {
+        this.size = size;
+    }
+
+    public boolean isDirectoryFlag() {
+        return directoryFlag;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
 }

--- a/src/main/java/org/auscope/portal/server/vegl/VEGLJob.java
+++ b/src/main/java/org/auscope/portal/server/vegl/VEGLJob.java
@@ -10,7 +10,6 @@ import org.apache.commons.logging.LogFactory;
 import org.auscope.portal.core.cloud.CloudJob;
 import org.auscope.portal.server.gridjob.FileInformation;
 import org.auscope.portal.server.vegl.VglParameter.ParameterType;
-import org.auscope.portal.server.web.service.scm.Solution;
 
 /**
  * A specialisation of a generic cloud job for the VEGL Portal

--- a/src/main/java/org/auscope/portal/server/vegl/VEGLJob.java
+++ b/src/main/java/org/auscope/portal/server/vegl/VEGLJob.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.auscope.portal.core.cloud.CloudJob;
+import org.auscope.portal.server.gridjob.FileInformation;
 import org.auscope.portal.server.vegl.VglParameter.ParameterType;
 import org.auscope.portal.server.web.service.scm.Solution;
 
@@ -32,6 +33,9 @@ public class VEGLJob extends CloudJob implements Cloneable {
     private Map<String, VglParameter> jobParameters = new HashMap<String, VglParameter>();
     /** A list of VglDownload objects associated with this job*/
     private List<VglDownload> jobDownloads = new ArrayList<VglDownload>();
+
+    /** A list of FileInformation objects associated with this job*/
+    private List<FileInformation> jobFiles = new ArrayList<FileInformation>();
 
     /**
      * Creates an unitialised VEGLJob
@@ -193,6 +197,18 @@ public class VEGLJob extends CloudJob implements Cloneable {
         this.jobDownloads = jobDownloads;
         for (VglDownload dl : jobDownloads) {
             dl.setParent(this);
+        }
+    }
+
+
+    public List<FileInformation> getJobFiles() {
+        return jobFiles;
+    }
+
+    public void setJobFiles(List<FileInformation> jobFiles) {
+        this.jobFiles = jobFiles;
+        for (FileInformation fi : jobFiles) {
+            fi.setParent(this);
         }
     }
 

--- a/src/main/java/org/auscope/portal/server/web/service/VHIRLProvenanceService.java
+++ b/src/main/java/org/auscope/portal/server/web/service/VHIRLProvenanceService.java
@@ -17,11 +17,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.io.*;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
-import java.text.SimpleDateFormat;
 import java.util.*;
 
 /**

--- a/src/main/resources/fileinformation.hbm.xml
+++ b/src/main/resources/fileinformation.hbm.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+<hibernate-mapping>
+    <class name="org.auscope.portal.server.gridjob.FileInformation" table="uploads">
+        <id name="id" column="id">
+            <generator class="native"/>
+        </id>
+
+        <property name="name"/>
+        <property name="fileName"/>
+        <property name="size"/>
+        <property name="directoryFlag"/>
+        <property name="parentPath"/>
+        <property name="owner"/>
+        <property name="date"/>
+        <property name="description"/>
+        <property name="copyright"/>
+
+        <many-to-one name="parent" column="jobId" not-null="true"></many-to-one>
+    </class>
+</hibernate-mapping>
+

--- a/src/main/resources/vegljob.hbm.xml
+++ b/src/main/resources/vegljob.hbm.xml
@@ -36,5 +36,10 @@
             <key column="jobId" />
             <one-to-many class="org.auscope.portal.server.vegl.VglDownload" />
         </bag>
+
+        <bag name="jobFiles" lazy="false" cascade="all-delete-orphan" inverse="true">
+            <key column="jobId" />
+            <one-to-many class="org.auscope.portal.server.gridjob.FileInformation" />
+        </bag>
     </class>
 </hibernate-mapping>

--- a/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/src/main/webapp/WEB-INF/applicationContext.xml
@@ -362,6 +362,7 @@
                 <value>vgldownload.hbm.xml</value>
                 <value>vglsignature.hbm.xml</value>
                 <value>scmentrysnapshot.hbm.xml</value>
+                <value>fileinformation.hbm.xml</value>
             </list>
         </property>
         <property name="hibernateProperties">

--- a/src/main/webapp/js/vegl/widgets/JobInputFileWindow.js
+++ b/src/main/webapp/js/vegl/widgets/JobInputFileWindow.js
@@ -27,14 +27,6 @@ Ext.define('vegl.widgets.JobInputFileWindow', {
                     xtype : 'form',
                     itemId : 'tab-local',
                     title : 'From Local File',
-//                    items : [{
-//                        xtype: 'filefield',
-//                        name: 'file',
-//                        anchor : '100%',
-//                        labelWidth: 150,
-//                        allowBlank: false,
-//                        fieldLabel: 'Select File to upload'
-//                    }]
                       items: [{
                         xtype: 'multifilefield',
                         name: 'file',
@@ -43,6 +35,40 @@ Ext.define('vegl.widgets.JobInputFileWindow', {
                         anchor: '100%',
                         allowBlank: false,
                         margin: 0
+                      },{
+                        xtype : 'textfield',
+                        fieldLabel: 'Name',
+                        anchor : '100%',
+                        name : 'name',
+                        allowBlank : true
+                      },{
+                        xtype : 'textfield',
+                        fieldLabel: 'Owner Email',
+                        anchor : '100%',
+                        name : 'owner',
+                        allowBlank : true,
+                        vtype : 'email'
+                      },{
+                        xtype : 'datefield',
+                        fieldLabel: 'Date Created',
+                        anchor : '100%',
+                        name : 'date',
+                        format: 'd/m/Y',
+                        value: new Date(),
+                        allowBlank : true
+                      },{
+                        xtype : 'textfield',
+                        fieldLabel: 'Description',
+                        anchor : '100%',
+                        name : 'description',
+                        allowBlank : true
+                      },{
+	                    xtype : 'textfield',
+                        fieldLabel: 'Link to Copyright',
+                        anchor : '100%',
+                        name : 'copyright',
+                        allowBlank : true,
+                        vtype : 'url'
                       }]
                 },{
                     xtype : 'form',
@@ -106,10 +132,15 @@ Ext.define('vegl.widgets.JobInputFileWindow', {
             return;
         }
 
+        var params = form.getValues();
+        params.jobId = this.jobId;
+        params.append = true;
+
         //Submit our form so our files get uploaded...
         form.submit({
             url: 'uploadFile.do',
             scope : this,
+            params: params,
             success: function(form, action) {
                 if (!action.result.success) {
                     Ext.Msg.alert('Error uploading file. ' + action.result.error);
@@ -119,9 +150,6 @@ Ext.define('vegl.widgets.JobInputFileWindow', {
             },
             failure: function() {
                 Ext.Msg.alert('Failure', 'File upload failed. Please try again in a few minutes.');
-            },
-            params: {
-                jobId : this.jobId
             },
             waitMsg: 'Uploading file, please wait...',
             waitTitle: 'Upload file'

--- a/src/main/webapp/js/vegl/widgets/JobInputFilesPanel.js
+++ b/src/main/webapp/js/vegl/widgets/JobInputFilesPanel.js
@@ -95,7 +95,7 @@ Ext.define('vegl.widgets.JobInputFilesPanel', {
                 groupField : 'group',
                 data : []
             }),
-            columns: [{ header: 'Name', width: 200, sortable: true, dataIndex: 'name'},
+            columns: [{ header: 'File Name', width: 200, sortable: true, dataIndex: 'fileName'},
                       { header: 'Location', width: 200, dataIndex: 'localPath'},
                       { header: 'Details', flex : 1, dataIndex: 'details'}],
             tbar: [{

--- a/src/test/java/org/auscope/portal/server/web/controllers/TestJobBuilderController.java
+++ b/src/test/java/org/auscope/portal/server/web/controllers/TestJobBuilderController.java
@@ -207,30 +207,6 @@ public class TestJobBuilderController {
     }
 
     /**
-     * Tests that the retrieving of job files fails
-     * when the underlying file staging service fails.
-     * @throws Exception
-     */
-    @Test
-    public void testListJobFiles_Exception() throws Exception {
-        final String jobId = "1";
-        final VEGLJob mockJob = new VEGLJob(new Integer(jobId));
-
-        context.checking(new Expectations() {{
-            //We should have a call to our job manager to get our job object
-            oneOf(mockJobManager).getJobById(Integer.parseInt(jobId));
-            will(returnValue(mockJob));
-            //We should have a call to file staging service to get our files
-            oneOf(mockFileStagingService).listStageInDirectoryFiles(mockJob);
-            will(throwException(new PortalServiceException("test exception","test exception")));
-        }});
-
-        ModelAndView mav = controller.listJobFiles(jobId);
-        Assert.assertFalse((Boolean)mav.getModel().get("success"));
-        Assert.assertNull(mav.getModel().get("data"));
-    }
-
-    /**
      * Tests that the downloading of job file fails when
      * the underlying file staging service's file download handler fails.
      * @throws Exception
@@ -407,9 +383,12 @@ public class TestJobBuilderController {
 
             oneOf(mockFile).length();
             will(returnValue(1024L));
+
+            oneOf(mockJobManager).saveJob(jobObj);
+
         }});
 
-        ModelAndView mav = controller.uploadFile(mockMultipartRequest, mockResponse, jobObj.getId().toString());
+        ModelAndView mav = controller.uploadFile(mockMultipartRequest, mockResponse, jobObj.getId().toString(), "mock file", "mock.owner@mail.com", "12/01/2002", "http://creativecommons.org/licenses/by-nc-nd/4.0/", "mocking file");
         Assert.assertTrue((Boolean)mav.getModel().get("success"));
     }
 
@@ -433,7 +412,7 @@ public class TestJobBuilderController {
             will(throwException(new PortalServiceException("Test Exception","Test Exception")));
         }});
 
-        ModelAndView mav = controller.uploadFile(mockMultipartRequest, mockResponse, jobObj.getId().toString());
+        ModelAndView mav = controller.uploadFile(mockMultipartRequest, mockResponse, jobObj.getId().toString(), "mock file", "mock.owner@mail.com", "12/01/2002", "http://creativecommons.org/licenses/by-nc-nd/4.0/", "mocking file");
         Assert.assertFalse((Boolean)mav.getModel().get("success"));
     }
 
@@ -453,7 +432,7 @@ public class TestJobBuilderController {
             will(throwException(new Exception()));
         }});
 
-        ModelAndView mav = controller.uploadFile(mockMultipartRequest, mockResponse, jobObj.getId().toString());
+        ModelAndView mav = controller.uploadFile(mockMultipartRequest, mockResponse, jobObj.getId().toString(), "mock file", "mock.owner@mail.com", "12/01/2002", "http://creativecommons.org/licenses/by-nc-nd/4.0/", "mocking file");
         Assert.assertFalse((Boolean)mav.getModel().get("success"));
         Assert.assertNull(mav.getModel().get("data"));
     }

--- a/src/test/java/org/auscope/portal/server/web/service/VHIRLProvenanceServiceTest.java
+++ b/src/test/java/org/auscope/portal/server/web/service/VHIRLProvenanceServiceTest.java
@@ -5,8 +5,6 @@ import au.csiro.promsclient.Entity;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.ModelFactory;
 import junit.framework.Assert;
-import junit.framework.TestCase;
-import nu.xom.jaxen.util.SingletonList;
 import org.auscope.portal.core.cloud.CloudFileInformation;
 import org.auscope.portal.core.services.cloud.CloudStorageService;
 import org.auscope.portal.core.test.PortalTestClass;
@@ -78,7 +76,7 @@ public class VHIRLProvenanceServiceTest extends PortalTestClass {
         final CloudFileInformation[] cloudList = {cloudFileInformation, cloudFileModel};
 
         FileInformation input = new FileInformation(cloudKey, 0, false, "", "foo@bar.com", "12/02/2013");
-        final List<FileInformation> fileInfos = new SingletonList(input);
+        final List<FileInformation> fileInfos = Arrays.asList(input);
 
         turtleJob = context.mock(VEGLJob.class, "Turtle Mock Job");
 

--- a/src/test/java/org/auscope/portal/server/web/service/VHIRLProvenanceServiceTest.java
+++ b/src/test/java/org/auscope/portal/server/web/service/VHIRLProvenanceServiceTest.java
@@ -6,9 +6,11 @@ import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.ModelFactory;
 import junit.framework.Assert;
 import junit.framework.TestCase;
+import nu.xom.jaxen.util.SingletonList;
 import org.auscope.portal.core.cloud.CloudFileInformation;
 import org.auscope.portal.core.services.cloud.CloudStorageService;
 import org.auscope.portal.core.test.PortalTestClass;
+import org.auscope.portal.server.gridjob.FileInformation;
 import org.auscope.portal.server.vegl.VEGLJob;
 import org.auscope.portal.server.vegl.VglDownload;
 import org.jmock.Expectations;
@@ -75,6 +77,9 @@ public class VHIRLProvenanceServiceTest extends PortalTestClass {
         CloudFileInformation cloudFileModel = new CloudFileInformation(activityFileName, 0, "");
         final CloudFileInformation[] cloudList = {cloudFileInformation, cloudFileModel};
 
+        FileInformation input = new FileInformation(cloudKey, 0, false, "", "foo@bar.com", "12/02/2013");
+        final List<FileInformation> fileInfos = new SingletonList(input);
+
         turtleJob = context.mock(VEGLJob.class, "Turtle Mock Job");
 
         context.checking(new Expectations() {{
@@ -92,6 +97,8 @@ public class VHIRLProvenanceServiceTest extends PortalTestClass {
             will(returnValue(new Date()));
             allowing(preparedJob).getUser();
             will(returnValue("foo@test.com"));
+            allowing(preparedJob).getJobFiles();
+            will(returnValue(fileInfos));
 
             allowing(fileInformation).getCloudKey();
             will(returnValue(cloudKey));


### PR DESCRIPTION
Adds additional (optional) fields to the File Upload form when creating a Job. The new fields are:

* Name (free text)
* Owner (email address, defaults to user's account if not set)
* Description (free text)
* Copyright (url)

This information is saved to the database and then used to flesh out the provenance record.

This pull request introduces a *new database table*, `uploads`, to store upload metadata (previously the contents of the bucket were enumerated, no extra metadata was kept). This is linked to the Job by the Job ID.

This pull request addresses ANDSPROV-93.