### PR TITLE
1. Fix reporting to PROMS

### DIFF
--- a/src/main/java/org/auscope/portal/server/web/service/VHIRLProvenanceService.java
+++ b/src/main/java/org/auscope/portal/server/web/service/VHIRLProvenanceService.java
@@ -312,6 +312,8 @@ public class VHIRLProvenanceService {
         }
         Report report = new ExternalReport()
                 .setActivity(activity)
+                .setTitle(job.getName())
+                .setNativeId(Integer.toString(job.getId()))
                 .setReportingSystemUri(serverURL);
         ProvenanceReporter reporter = new ProvenanceReporter();
         int resp = reporter.postReport(PROMSURI, report);

--- a/src/main/java/org/auscope/portal/server/web/service/VHIRLProvenanceService.java
+++ b/src/main/java/org/auscope/portal/server/web/service/VHIRLProvenanceService.java
@@ -49,7 +49,7 @@ public class VHIRLProvenanceService {
     }
 
     /* Can be changed in application context */
-    private String promsUrl = "http://proms.csiro.au";
+    private String promsUrl = "http://proms-dev.vhirl.net/id/report/";
     private URI PROMSService = null;
 
     /** URL of the current webserver. Will need to be set by classes
@@ -388,6 +388,14 @@ public class VHIRLProvenanceService {
                 }
             }
             activity.setGeneratedEntities(outputs);
+            if (!PROMSService.toString().equals(promsUrl)) {
+                try {
+                    PROMSService = new URI(promsUrl);
+                } catch (URISyntaxException e) {
+                    LOGGER.debug(e.getLocalizedMessage());
+                }
+            }
+            LOGGER.info("Reporting to: " + PROMSService.toString());
             generateAndSaveReport(activity, PROMSService, job);
             StringWriter out = new StringWriter();
             activity.getGraph().write(out, TURTLE_FORMAT, serverURL());

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -46,7 +46,7 @@ auscope-portal-dev.erddapservice.url=http://siss2.anu.edu.au/erddap/griddap/
 auscope-portal-dev.smtp.server=smtp-relay.csiro.au
 auscope-portal-dev.localStageInDir=/home/vhirl-portal/stageIn/
 auscope-portal-dev.google.analytics.key=UA-34371908-2
-auscope-portal-dev.promsServiceUrl=http://proms-dev.vhirl.net
+auscope-portal-dev.promsServiceUrl=http://proms-dev.vhirl.net/id/report/
 
 
 vhirl-dev.googlemap.key=AIzaSyB3CLCabuVCT0aL9XtYUmzrxiM_rul23oQ
@@ -55,7 +55,7 @@ vhirl-dev.erddapservice.url=http://siss2.anu.edu.au/erddap/griddap/
 vhirl-dev.smtp.server=localhost
 vhirl-dev.localStageInDir=/home/vhirl-portal/stageIn/
 vhirl-dev.google.analytics.key=UA-53596166-1
-vhirl-dev.promsServiceUrl=http://proms-dev.vhirl.net
+vhirl-dev.promsServiceUrl=http://proms-dev.vhirl.net/id/report/
 
 vhirl-prod.googlemap.key=AIzaSyB3CLCabuVCT0aL9XtYUmzrxiM_rul23oQ
 vhirl-prod.jdbc.url=jdbc:mysql://localhost:3306/vhirlportal
@@ -63,4 +63,4 @@ vhirl-prod.erddapservice.url=http://siss2.anu.edu.au/erddap/griddap/
 vhirl-prod.smtp.server=localhost
 vhirl-prod.localStageInDir=/home/vhirl-portal/stageIn/
 vhirl-prod.google.analytics.key=UA-53596166-2
-vhirl-prod.promsServiceUrl=http://proms.vhirl.net
+vhirl-prod.promsServiceUrl=http://proms.vhirl.net/id/report/

--- a/src/test/java/org/auscope/portal/server/web/service/VHIRLProvenanceServiceTest.java
+++ b/src/test/java/org/auscope/portal/server/web/service/VHIRLProvenanceServiceTest.java
@@ -195,7 +195,7 @@ public class VHIRLProvenanceServiceTest extends PortalTestClass {
                     .setReportingSystemUri(new URI(serverURL));
             ProvenanceReporter reporter = new ProvenanceReporter();
             int resp = reporter.postReport(new URI(PROMSURI), report);
-            Assert.assertEquals(200, resp);
+            Assert.assertTrue((resp == 200 || resp == 201));
         }
 
 

--- a/src/test/java/org/auscope/portal/server/web/service/VHIRLProvenanceServiceTest.java
+++ b/src/test/java/org/auscope/portal/server/web/service/VHIRLProvenanceServiceTest.java
@@ -1,7 +1,6 @@
 package org.auscope.portal.server.web.service;
 
-import au.csiro.promsclient.Activity;
-import au.csiro.promsclient.Entity;
+import au.csiro.promsclient.*;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.ModelFactory;
 import junit.framework.Assert;
@@ -33,6 +32,7 @@ public class VHIRLProvenanceServiceTest extends PortalTestClass {
     final String jobName = "Cool Job";
     final String jobDescription = "Some job I made.";
     final String activityFileName = "activity.ttl";
+    final String PROMSURI = "http://proms-dev.vhirl.net/id/report/";
     Solution solution;
     List<VglDownload> downloads = new ArrayList<>();
     VEGLJob turtleJob;
@@ -170,6 +170,35 @@ public class VHIRLProvenanceServiceTest extends PortalTestClass {
         String graph = vhirlProvenanceService.createEntitiesForOutputs(preparedJob);
         Assert.assertTrue(graph.contains(initalTurtle));
         Assert.assertTrue(graph.contains(endedTurtle));
+    }
+
+    @Test
+    public void testPost() throws Exception {
+        Set<Entity> outputs = new HashSet<>();
+        InputStream activityStream = getClass().getResourceAsStream("/activity.ttl");
+        Activity activity;
+        Model model = ModelFactory.createDefaultModel();
+        model = model.read(activityStream,
+                serverURL,
+                "TURTLE");
+        activity = new Activity().setActivityUri(new URI(
+                vhirlProvenanceService.jobURL(turtleJob, serverURL))).setFromModel(model);
+        if (activity != null) {
+            activity.setEndedAtTime(new Date());
+            String outputURL = serverURL + "/secure/jobFile.do?jobId=21&key=job-macgo-bt-everbloom_gmail_com-0000000021/1000_yrRP_hazard_map.png";
+            outputs.add(new Entity().setDataUri(new URI(outputURL)).setWasAttributedTo(new URI("mailto:jo@blogs.com")).setTitle("1000_yrRP_hazard_map.png"));
+            activity.setGeneratedEntities(outputs);
+            Report report = new ExternalReport()
+                    .setActivity(activity)
+                    .setTitle(jobName)
+                    .setNativeId(Integer.toString(jobID))
+                    .setReportingSystemUri(new URI(serverURL));
+            ProvenanceReporter reporter = new ProvenanceReporter();
+            int resp = reporter.postReport(new URI(PROMSURI), report);
+            Assert.assertEquals(200, resp);
+        }
+
+
     }
 
     @Test

--- a/src/test/resources/activity.ttl
+++ b/src/test/resources/activity.ttl
@@ -9,7 +9,7 @@
       a       <http://www.w3.org/ns/prov#Activity> ;
       <http://purl.org/dc/elements/1.1/description>
               "Some job I made."^^<http://www.w3.org/2001/XMLSchema#string> ;
-      <http://purl.org/dc/elements/1.1/title>
+      <http://www.w3.org/2000/01/rdf-schema#label>
               "Cool Job"^^<http://www.w3.org/2001/XMLSchema#string> ;
       <http://www.w3.org/ns/prov#startedAtTime>
               "2014-12-17T14:22:45+11:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -29,7 +29,7 @@
       a       <http://www.w3.org/ns/prov#Entity> ;
       <http://promsns.org/def/proms#serviceBaseUri>
               "http://portal-uploads.vhirl.org/file1"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-      <http://purl.org/dc/elements/1.1/title>
+      <http://www.w3.org/2000/01/rdf-schema#label>
               "file1"^^<http://www.w3.org/2001/XMLSchema#string> ;
       <http://www.w3.org/ns/dcat#downloadURL>
               "http://portal-uploads.vhirl.org/file1"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;


### PR DESCRIPTION
1. Now matches (undocumented) requirement that a Report have a Title (Label) and a Native ID.
2. Fix PROMS urls for VHIRL-Dev and Prod. PROMS does not compose URLs from the domain, full URLs must be supplied.
3. Include a test case that tests we can reach VHIRL-Dev and push a (canned) report. This test case should mean we have a check for Travis that PROMS integration is still working (not just PROV document production).